### PR TITLE
Create a temporary venv to install a recent virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,12 @@ test: .build/dev-requirements.timestamp
 
 .build/venv:
 	mkdir -p $(dir $@)
-	virtualenv .build/venv
-	.build/venv/bin/pip install --upgrade pip
+	# make a first virtualenv to get a recent version of virtualenv
+	virtualenv venv
+	venv/bin/pip install virtualenv
+	venv/bin/virtualenv .build/venv
+	# remove the temporary virtualenv
+	rm -rf venv
 
 .build/dev-requirements.timestamp: .build/venv dev-requirements.txt
 	mkdir -p $(dir $@)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,4 @@
 # This file defines the requirements.txt for development.
 #
 nose
-flake8==2.2.2
-pep8-naming==0.2.2
+flake8==2.5.0


### PR DESCRIPTION
Because the version of virtualenv installed as a system package may not be up-to-date, we sometimes get flake8 installed with no extensions.
This pull request fixes it by installing virtualenv in a temporary virtual environnement in order to create the one we want to use for the application.
Please review.
