### PR TITLE
Add preprocessed hazardsets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,106 @@ For more options, see::
 
     $ make help
 
+Configure using thinkhazard_processing.yaml
+===========================================
+
+Keys in configuration file:
+
+sqlalchemy.url
+--------------
+
+Database connection parameters, example :
+
+.. code:: yaml
+
+    sqlalchemy.url: postgresql://www-data:www-data@localhost:5432/thinkhazard_processing
+
+data_path
+---------
+
+Path to main data folder, example :
+
+.. code:: yaml
+
+    data_path: /var/sig
+
+hazard_types
+------------
+
+Harvesting and processing configuration for each hazard type.
+One entry for each hazard type mnemonic, with subkeys :
+
+- ``hazard_type`` : Corresponding hazard_type value in geonode.
+
+- ``preprocessed`` : Mandatory processing method. Possible values are :
+
+  1) ``True`` : One preprocessed layer with values corresponding directly to
+     hazard levels.
+
+     Need a corresponding ``values`` configuration.
+
+  2) ``False`` : One layer per hazard level.
+
+     Need corresponding ``return_periods`` and ``thresholds`` configurations.
+
+  3) ``None`` : Do not process.
+
+- ``return_periods`` : One entry for each hazard level mnemonic with
+  corresponding return periods. Each return period can be a value or a list
+  with minimum and maximum values, example:
+
+  .. code:: yaml
+
+      return_periods:
+        HIG: [10, 25]
+        MED: 50
+        LOW: [100, 1000]
+
+- ``thresholds`` : Flexible threshold configuration.
+
+  This can be a simple and global value for hazardtype. Example:
+
+  .. code:: yaml
+
+       thresholds: 1700
+
+  But it can also contains one or many sublevels for complex configurations :
+
+  1) ``global`` and ``local`` entries for corresponding hazardsets.
+  2) One entry for each hazard level mnemonic.
+  3) One entry for each hazard unit from geonode.
+
+  Example:
+
+  .. code:: yaml
+
+       thresholds:
+         global:
+           HIG:
+             unit1: value1
+             unit2: value2
+           MED:
+             unit1: value1
+             unit2: value2
+           LOW:
+             unit1: value1
+             unit2: value2
+         local:
+           unit1: value1
+           unit2: value2
+
+- ``values`` : One entry for each hazard level,
+  with list of corresponding values in preprocessed layer.
+  Example:
+
+  .. code:: yaml
+
+      values:
+        HIG: [103]
+        MED: [102]
+        LOW: [101]
+        VLO: [100, 0]
+
 Use ``local_settings.yaml``
 ===========================
 
@@ -33,6 +133,21 @@ For example, you can define a specific database connection with a
 ``local_settings.yaml`` file that looks like this::
 
     sqlalchemy.url: postgresql://www-data:www-data@localhost:9999/thinkhazard
+
+Processing tasks
+================
+
+Thinkhazard_processing provide some consecutive tasks to produce data for the
+thinkhazard datamart database. These are:
+
+``.build/venv/bin/process [--hazarset_id ...] [--force] [--dry-run]``
+
+Calculate output from hazardsets and administrative divisions.
+
+``.build/venv/bin/decision_tree [--force] [--dry-run]``
+
+Apply decision tree on process outputs to get final relations between
+administrative divisions and hazard categories.
 
 Run tests
 =========

--- a/README.rst
+++ b/README.rst
@@ -51,22 +51,11 @@ hazard_types
 ------------
 
 Harvesting and processing configuration for each hazard type.
-One entry for each hazard type mnemonic, with subkeys:
+One entry for each hazard type mnemonic.
+
+Possible subkeys include the following:
 
 - ``hazard_type``: Corresponding hazard_type value in geonode.
-
-- ``preprocessed``: Mandatory processing method. Possible values are:
-
-  1) ``True``: One preprocessed layer with values corresponding directly to
-     hazard levels.
-
-     Needs a corresponding ``values`` configuration.
-
-  2) ``False``: One layer per hazard level.
-
-     Needs corresponding ``return_periods`` and ``thresholds`` configurations.
-
-  3) ``None``: Do not process.
 
 - ``return_periods``: One entry per hazard level mnemonic with
   corresponding return periods. Each return period can be a value or a list
@@ -114,6 +103,8 @@ One entry for each hazard type mnemonic, with subkeys:
 
 - ``values``: One entry per hazard level,
   with list of corresponding values in preprocessed layer.
+  If present, the layer is considered as preprocessed, and the above
+  ``thresholds`` and ``return_periods`` are not taken into account.
   Example:
 
   .. code:: yaml

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Keys in configuration file:
 sqlalchemy.url
 --------------
 
-Database connection parameters, example :
+Database connection parameters, example:
 
 .. code:: yaml
 
@@ -39,34 +39,36 @@ Database connection parameters, example :
 data_path
 ---------
 
-Path to main data folder, example :
+Path to main data folder, example:
 
 .. code:: yaml
 
     data_path: /var/sig
 
+For production, we recommend a dedicated disk partition.
+
 hazard_types
 ------------
 
 Harvesting and processing configuration for each hazard type.
-One entry for each hazard type mnemonic, with subkeys :
+One entry for each hazard type mnemonic, with subkeys:
 
-- ``hazard_type`` : Corresponding hazard_type value in geonode.
+- ``hazard_type``: Corresponding hazard_type value in geonode.
 
-- ``preprocessed`` : Mandatory processing method. Possible values are :
+- ``preprocessed``: Mandatory processing method. Possible values are:
 
-  1) ``True`` : One preprocessed layer with values corresponding directly to
+  1) ``True``: One preprocessed layer with values corresponding directly to
      hazard levels.
 
-     Need a corresponding ``values`` configuration.
+     Needs a corresponding ``values`` configuration.
 
-  2) ``False`` : One layer per hazard level.
+  2) ``False``: One layer per hazard level.
 
-     Need corresponding ``return_periods`` and ``thresholds`` configurations.
+     Needs corresponding ``return_periods`` and ``thresholds`` configurations.
 
-  3) ``None`` : Do not process.
+  3) ``None``: Do not process.
 
-- ``return_periods`` : One entry for each hazard level mnemonic with
+- ``return_periods``: One entry per hazard level mnemonic with
   corresponding return periods. Each return period can be a value or a list
   with minimum and maximum values, example:
 
@@ -77,19 +79,19 @@ One entry for each hazard type mnemonic, with subkeys :
         MED: 50
         LOW: [100, 1000]
 
-- ``thresholds`` : Flexible threshold configuration.
+- ``thresholds``: Flexible threshold configuration.
 
-  This can be a simple and global value for hazardtype. Example:
+  This can be a simple and global value per hazardtype. Example:
 
   .. code:: yaml
 
        thresholds: 1700
 
-  But it can also contains one or many sublevels for complex configurations :
+  But it can also contain one or many sublevels for complex configurations:
 
   1) ``global`` and ``local`` entries for corresponding hazardsets.
-  2) One entry for each hazard level mnemonic.
-  3) One entry for each hazard unit from geonode.
+  2) One entry per hazard level mnemonic.
+  3) One entry per hazard unit from geonode.
 
   Example:
 
@@ -110,7 +112,7 @@ One entry for each hazard type mnemonic, with subkeys :
            unit1: value1
            unit2: value2
 
-- ``values`` : One entry for each hazard level,
+- ``values``: One entry per hazard level,
   with list of corresponding values in preprocessed layer.
   Example:
 
@@ -137,7 +139,7 @@ For example, you can define a specific database connection with a
 Processing tasks
 ================
 
-Thinkhazard_processing provide some consecutive tasks to produce data for the
+Thinkhazard_processing provides several consecutive tasks to populate the
 thinkhazard datamart database. These are:
 
 ``.build/venv/bin/process [--hazarset_id ...] [--force] [--dry-run]``
@@ -146,8 +148,8 @@ Calculate output from hazardsets and administrative divisions.
 
 ``.build/venv/bin/decision_tree [--force] [--dry-run]``
 
-Apply decision tree on process outputs to get final relations between
-administrative divisions and hazard categories.
+Apply the decision tree followed by upscaling on process outputs to get the final
+relations between administrative divisions and hazard categories.
 
 Run tests
 =========

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ PyYAML==3.11
 rasterio==0.30.0
 pyproj==1.9.4
 shapely==1.5.13
-git+https://github.com/GFDRR/thinkhazard_common.git#egg=thinkhazard_common
+git+https://github.com/GFDRR/thinkhazard_common.git@fbbadb3f50722541c0cc701bd20c31c6c3bb7d7c#egg=thinkhazard_common
 -e .

--- a/thinkhazard_processing.yaml
+++ b/thinkhazard_processing.yaml
@@ -2,19 +2,12 @@ sqlalchemy.url: postgresql://www-data:www-data@localhost:5432/thinkhazard_proces
 data_path: /var/sig
 
 hazard_types:
-  EQ:
-    hazard_type: earthquake
-    return_periods:
-        HIG: [100, 250]
-        MED: [475, 475]
-        LOW: [2475, 2500]
-    thresholds: 98.0665
-
   FL:
     hazard_type: river_flood
+    preprocessed: False
     return_periods:
       HIG: [10, 25]
-      MED: [50, 50]
+      MED: 50
       LOW: [100, 1000]
     thresholds:
       global:
@@ -26,21 +19,59 @@ hazard_types:
         dm: 5
         m: 0.5
 
+  EQ:
+    hazard_type: earthquake
+    preprocessed: False
+    return_periods:
+      HIG: [100, 250]
+      MED: [475, 475]
+      LOW: [2475, 2500]
+    thresholds: 98.0665
+
+  DG:
+    hazard_type: drought
+    preprocessed: False
+    return_periods:
+      HIG: 5
+      MED: 50
+      LOW: 1000
+    inverted_comparison: True
+    thresholds: 1700
+
+  VA:
+    hazard_type: volcanic_ash
+    preprocessed: True
+    values:
+      HIG: [103]
+      MED: [102]
+      LOW: [101]
+      VLO: [100, 0]
+
   CY:
     hazard_type: strong_wind
+    preprocessed: False
     return_periods:
-      HIG: [50, 50]
-      MED: [100, 100]
-      LOW: [500, 1000]
+      HIG: 50
+      MED: 100
+      LOW: 1000
     thresholds:
       "km/h": 80
 
+  TS:
+    hazard_type: tsunami
+    preprocessed: True
+    values:
+      HIG: [1]
+      MED: [2]
+      LOW: [3]
+
   SS:
     hazard_type: coastal_flood
+    preprocessed: False
     return_periods:
-      HIG: [10, 50]
-      MED: [100, 100]
-      LOW: [250, 1000]
+      HIG: 10
+      MED: 50
+      LOW: 100
     thresholds:
       HIG: 2
       MED: 0.5

--- a/thinkhazard_processing.yaml
+++ b/thinkhazard_processing.yaml
@@ -1,37 +1,47 @@
 sqlalchemy.url: postgresql://www-data:www-data@localhost:5432/thinkhazard_processing
+data_path: /var/sig
 
 hazard_types:
-  FL:
-    hazard_type: river_flood
-    global:
-      return_periods:
-        LOW: 1000
-        MED: 50
-        HIG: 25
-    local:
-      return_periods:
-        LOW: 100
-        MED: 50
-        HIG: 25
-    thresholds:
-      cm: 100
-      dm: 10
-      m: 1
   EQ:
     hazard_type: earthquake
-    global:
-      return_periods:
-        LOW: 2475
-        MED: 475
-        HIG: 250
-    local:
-      return_periods:
-        LOW: 2500
-        MED: 475
-        HIG: 100
-    thresholds:
-      PGA-gal: 98.0665
-      PGA-g: 98.0665
-      SA-g: 98.0665
+    return_periods:
+        HIG: [100, 250]
+        MED: [475, 475]
+        LOW: [2475, 2500]
+    thresholds: 98.0665
 
-data_path: /tmp
+  FL:
+    hazard_type: river_flood
+    return_periods:
+      HIG: [10, 25]
+      MED: [50, 50]
+      LOW: [100, 1000]
+    thresholds:
+      global:
+        cm: 100
+        dm: 10
+        m: 1
+      local:
+        cm: 50
+        dm: 5
+        m: 0.5
+
+  CY:
+    hazard_type: strong_wind
+    return_periods:
+      HIG: [50, 50]
+      MED: [100, 100]
+      LOW: [500, 1000]
+    thresholds:
+      "km/h": 80
+
+  SS:
+    hazard_type: coastal_flood
+    return_periods:
+      HIG: [10, 50]
+      MED: [100, 100]
+      LOW: [250, 1000]
+    thresholds:
+      HIG: 2
+      MED: 0.5
+      LOW: 0.5

--- a/thinkhazard_processing.yaml
+++ b/thinkhazard_processing.yaml
@@ -4,7 +4,6 @@ data_path: /var/sig
 hazard_types:
   FL:
     hazard_type: river_flood
-    preprocessed: False
     return_periods:
       HIG: [10, 25]
       MED: 50
@@ -21,7 +20,6 @@ hazard_types:
 
   EQ:
     hazard_type: earthquake
-    preprocessed: False
     return_periods:
       HIG: [100, 250]
       MED: [475, 475]
@@ -30,7 +28,6 @@ hazard_types:
 
   DG:
     hazard_type: drought
-    preprocessed: False
     return_periods:
       HIG: 5
       MED: 50
@@ -40,7 +37,6 @@ hazard_types:
 
   VA:
     hazard_type: volcanic_ash
-    preprocessed: True
     values:
       HIG: [103]
       MED: [102]
@@ -49,7 +45,6 @@ hazard_types:
 
   CY:
     hazard_type: strong_wind
-    preprocessed: False
     return_periods:
       HIG: 50
       MED: 100
@@ -59,7 +54,6 @@ hazard_types:
 
   TS:
     hazard_type: tsunami
-    preprocessed: True
     values:
       HIG: [1]
       MED: [2]
@@ -67,7 +61,6 @@ hazard_types:
 
   SS:
     hazard_type: coastal_flood
-    preprocessed: False
     return_periods:
       HIG: 10
       MED: 50

--- a/thinkhazard_processing/__init__.py
+++ b/thinkhazard_processing/__init__.py
@@ -1,18 +1,6 @@
 import os
 import yaml
 
-from sqlalchemy.orm import (
-    scoped_session,
-    sessionmaker,
-    )
-from zope.sqlalchemy import ZopeTransactionExtension
-
-# Overwrite the DBSession class with option keep_session=True
-# we don't want session to be closed on commit in the processing package.
-from thinkhazard_common import models
-models.DBSession = scoped_session(sessionmaker(
-    extension=ZopeTransactionExtension(keep_session=True)))
-
 
 def load_settings():
     root_folder = os.path.join(os.path.dirname(__file__), '..')

--- a/thinkhazard_processing/models.py
+++ b/thinkhazard_processing/models.py
@@ -77,26 +77,27 @@ class HazardSet(Base):
 class Layer(Base):
     __tablename__ = 'layer'
     __table_args__ = {u'schema': 'processing'}
+
+    # the layer is referenced in geonode with an id:
+    geonode_id = Column(Integer, primary_key=True)
+
     # a layer is identified by it's return_period and hazard_set:
     hazardset_id = Column(String, ForeignKey('processing.hazardset.id'),
-                          primary_key=True)
+                          nullable=False)
     # the related hazard_level, inferred from return_period
     hazardlevel_id = Column(Integer,
-                            ForeignKey('datamart.enum_hazardlevel.id'),
-                            primary_key=True)
+                            ForeignKey('datamart.enum_hazardlevel.id'))
     # the return period is typically 100, 475, 2475 years but it can vary
-    return_period = Column(Integer, nullable=False)
+    return_period = Column(Integer)
 
     # pixel values have a unit:
-    hazardunit = Column(String, nullable=False)
+    hazardunit = Column(String)
 
     # date the data was last updated (defaults to created):
     data_lastupdated_date = Column(Date, nullable=False)
     # date the metadata was last updated (defaults to created):
     metadata_lastupdated_date = Column(Date, nullable=False)
 
-    # the layer is referenced in geonode with an id:
-    geonode_id = Column(Integer, nullable=False, unique=True)
     # the data can be downloaded at this URL:
     download_url = Column(String, nullable=False)
 
@@ -119,7 +120,10 @@ class Layer(Base):
     hazardlevel = relationship('HazardLevel')
 
     def name(self):
-        return '{}-{}'.format(self.hazardset_id, self.return_period)
+        if self.return_period is None:
+            return self.hazardset_id
+        else:
+            return '{}-{}'.format(self.hazardset_id, self.return_period)
 
     def path(self):
         return os.path.join(settings['data_path'],

--- a/thinkhazard_processing/processing.py
+++ b/thinkhazard_processing/processing.py
@@ -73,8 +73,6 @@ def process_hazardset(hazardset, force=False):
     DBSession.flush()
 
     hazardtype = hazardset.hazardtype
-    hazardtype_settings = settings['hazard_types'][hazardtype.mnemonic]
-    thresholds = hazardtype_settings['thresholds']
 
     project = partial(
         pyproj.transform,
@@ -113,6 +111,7 @@ def process_hazardset(hazardset, force=False):
                 .filter(AdministrativeDivision.leveltype_id == adminlevel_REG.id) \
 
             if hazardset.local:
+                # TODO : this could be optimized
                 admindivs = admindivs \
                     .filter(
                         func.ST_Transform(AdministrativeDivision.geom, 4326)
@@ -158,7 +157,18 @@ def process_hazardset(hazardset, force=False):
                     if data.shape[0] * data.shape[1] == 0:
                         continue
 
-                    threshold = thresholds[layer.hazardunit]
+                    threshold = get_threshold(hazardtype.mnemonic,
+                                              layer.local,
+                                              layer.hazardlevel.mnemonic,
+                                              layer.hazardunit)
+                    if threshold is None:
+                        print ("WARNING: no threshold found for {} {} {} {}"
+                               .format(hazardtype.mnemonic,
+                                       'local' if layer.local else 'global',
+                                       layer.hazardlevel.mnemonic,
+                                       layer.hazardunit))
+                        transaction.rollback()
+                        return False
                     positive_data = (data > threshold).astype(rasterio.uint8)
 
                     division = features.rasterize(
@@ -207,3 +217,16 @@ def polygonFromBounds(bounds):
         (bounds[2], bounds[3]),
         (bounds[2], bounds[1]),
         (bounds[0], bounds[1])])
+
+
+def get_threshold(hazardtype, local, level, unit):
+    mysettings = settings['hazard_types'][hazardtype]['thresholds']
+    if type(mysettings) is float:
+        return mysettings
+    if 'local' in mysettings.keys():
+        mysettings = mysettings['local'] if local else mysettings['global']
+    if 'HIG' in mysettings.keys():
+        mysettings = mysettings[level]
+    if unit in mysettings.keys():
+        mysettings = mysettings[unit]
+        return float(mysettings)

--- a/thinkhazard_processing/processing.py
+++ b/thinkhazard_processing/processing.py
@@ -221,8 +221,8 @@ def polygonFromBounds(bounds):
 
 def get_threshold(hazardtype, local, level, unit):
     mysettings = settings['hazard_types'][hazardtype]['thresholds']
-    if type(mysettings) is float:
-        return mysettings
+    if type(mysettings) in (int, float):
+        return float(mysettings)
     if 'local' in mysettings.keys():
         mysettings = mysettings['local'] if local else mysettings['global']
     if 'HIG' in mysettings.keys():

--- a/thinkhazard_processing/processing.py
+++ b/thinkhazard_processing/processing.py
@@ -57,7 +57,7 @@ def process(hazardset_id=None, force=False, dry_run=False):
     if not force:
         ids = ids.filter(HazardSet.processed.is_(False))
     if ids.count() == 0:
-        logger.info('No hazardsets to process')
+        logger.info('No hazardset to process')
         return
     for id in ids:
         logger.info(id[0])
@@ -77,7 +77,7 @@ def process(hazardset_id=None, force=False, dry_run=False):
 def process_hazardset(hazardset_id, force=False):
     hazardset = DBSession.query(HazardSet).get(hazardset_id)
     if hazardset is None:
-        raise ProcessException('HazardSet {} does not exist.'
+        raise ProcessException('Hazardset {} does not exist.'
                                .format(hazardset_id))
 
     chrono = datetime.datetime.now()
@@ -86,7 +86,7 @@ def process_hazardset(hazardset_id, force=False):
         if force:
             hazardset.processed = False
         else:
-            raise ProcessException('HazardSet {} has already been processed.'
+            raise ProcessException('Hazardset {} has already been processed.'
                                    .format(hazardset.id))
 
     logger.info("  Cleaning previous outputs")
@@ -99,7 +99,7 @@ def process_hazardset(hazardset_id, force=False):
 
     with rasterio.drivers():
         try:
-            logger.info("  Openning raster files")
+            logger.info("  Opening raster files")
             # Open rasters
             layers = {}
             readers = {}
@@ -178,7 +178,6 @@ def create_outputs(hazardset, layers, readers):
     total = admindivs.count()
     logger.info('  Iterating over {} administrative divisions'.format(total))
     for admindiv in admindivs:
-        # print ' ', admindiv.id, admindiv.code, admindiv.name
 
         current += 1
         if admindiv.geom is None:
@@ -205,7 +204,7 @@ def create_outputs(hazardset, layers, readers):
                                                           reprojected)
 
         except Exception as e:
-            e.message = ("{}-{} raise an exception :\n{}"
+            e.message = ("{}-{} raises an exception :\n{}"
                          .format(admindiv.code, admindiv.name, e.message))
             raise
 

--- a/thinkhazard_processing/processing.py
+++ b/thinkhazard_processing/processing.py
@@ -1,16 +1,14 @@
-# -*- coding: utf-8 -*-
-
+import logging
 import transaction
 import datetime
 import numpy
 import rasterio
 import pyproj
-from rasterio import features
-from shapely.ops import (
-    transform,
-    cascaded_union
-)
-from shapely.geometry import Polygon
+from rasterio import (
+    features,
+    window_shape)
+from shapely.ops import transform
+from shapely.geometry import box
 from functools import partial
 from geoalchemy2.shape import to_shape
 from sqlalchemy import func
@@ -29,35 +27,60 @@ from .models import (
 from . import settings
 
 
+logger = logging.getLogger(__name__)
+
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+logger.setLevel(logging.DEBUG)
+
+
+project = partial(
+    pyproj.transform,
+    pyproj.Proj(init='epsg:3857'),
+    pyproj.Proj(init='epsg:4326'))
+
+
 class ProcessException(Exception):
     def __init__(self, message):
         self.message = message
 
 
-def process(hazardset_id=None, force=False):
-    hazardsets = DBSession.query(HazardSet)
-    hazardsets = hazardsets.filter(HazardSet.complete.is_(True))
+def process(hazardset_id=None, force=False, dry_run=False):
+    ids = DBSession.query(HazardSet.id) \
+        .filter(HazardSet.complete.is_(True))
     if hazardset_id is not None:
-        hazardsets = hazardsets.filter(HazardSet.id == hazardset_id)
+        ids = ids.filter(HazardSet.id == hazardset_id)
     if not force:
-        hazardsets = hazardsets.filter(HazardSet.processed.is_(False))
-    if hazardsets.count() == 0:
-        print 'No hazardsets to process'
+        ids = ids.filter(HazardSet.processed.is_(False))
+    if ids.count() == 0:
+        logger.info('No hazardsets to process')
         return
-    for hazardset in hazardsets:
-        process_hazardset(hazardset, force=force)
+    for id in ids:
+        logger.info(id[0])
+        try:
+            process_hazardset(id[0], force=force)
+            if dry_run:
+                logger.info('  Abording transaction')
+                transaction.abort()
+            else:
+                logger.info('  Committing transaction')
+                transaction.commit()
+        except Exception as e:
+            transaction.abort()
+            logger.error(e.message)
 
 
-def process_hazardset(hazardset, force=False):
-    print hazardset.id
-    chrono = datetime.datetime.now()
-    last_percent = 0
-
-    level_VLO = HazardLevel.get(u'VLO')
-
+def process_hazardset(hazardset_id, force=False):
+    hazardset = DBSession.query(HazardSet).get(hazardset_id)
     if hazardset is None:
         raise ProcessException('HazardSet {} does not exist.'
-                               .format(hazardset.id))
+                               .format(hazardset_id))
+
+    chrono = datetime.datetime.now()
 
     if hazardset.processed:
         if force:
@@ -66,167 +89,283 @@ def process_hazardset(hazardset, force=False):
             raise ProcessException('HazardSet {} has already been processed.'
                                    .format(hazardset.id))
 
-    # clean previous outputs
+    logger.info("  Cleaning previous outputs")
     DBSession.query(Output) \
         .filter(Output.hazardset_id == hazardset.id) \
         .delete()
     DBSession.flush()
 
-    hazardtype = hazardset.hazardtype
-
-    project = partial(
-        pyproj.transform,
-        pyproj.Proj(init='epsg:3857'),
-        pyproj.Proj(init='epsg:4326'))
-
-    layers = {}
-    for level in (u'HIG', u'MED', u'LOW'):
-        hazardlevel = HazardLevel.get(level)
-        layer = DBSession.query(Layer) \
-            .filter(Layer.hazardset_id == hazardset.id) \
-            .filter(Layer.hazardlevel_id == hazardlevel.id) \
-            .one()
-        layers[level] = layer
+    type_settings = settings['hazard_types'][hazardset.hazardtype.mnemonic]
 
     with rasterio.drivers():
-        with rasterio.open(layers['HIG'].path()) as src_hig, \
-                rasterio.open(layers['MED'].path()) as src_med, \
-                rasterio.open(layers['LOW'].path()) as src_low:
+        try:
+            logger.info("  Openning raster files")
+            # Open rasters
+            layers = {}
             readers = {}
-            readers['HIG'] = src_hig
-            readers['MED'] = src_med
-            readers['LOW'] = src_low
+            if type_settings['preprocessed']:
+                layer = DBSession.query(Layer) \
+                    .filter(Layer.hazardset_id == hazardset.id) \
+                    .one()
+                reader = rasterio.open(layer.path())
 
-            polygon_hig = polygonFromBounds(src_hig.bounds)
-            polygon_med = polygonFromBounds(src_med.bounds)
-            polygon_low = polygonFromBounds(src_low.bounds)
-            polygon = cascaded_union((
-                polygon_hig,
-                polygon_med,
-                polygon_low))
+                layers[0] = layer
+                readers[0] = reader
 
-            adminlevel_REG = AdminLevelType.get(u'REG')
-
-            admindivs = DBSession.query(AdministrativeDivision) \
-                .filter(AdministrativeDivision.leveltype_id == adminlevel_REG.id) \
-
-            if hazardset.local:
-                # TODO : this could be optimized
-                admindivs = admindivs \
-                    .filter(
-                        func.ST_Transform(AdministrativeDivision.geom, 4326)
-                        .intersects(
-                            func.ST_GeomFromText(polygon.wkt, 4326))) \
-                    .filter(func.ST_Intersects(
-                        func.ST_Transform(AdministrativeDivision.geom, 4326),
-                        func.ST_GeomFromText(polygon.wkt, 4326)))
-
-            current = 0
-            outputs = 0
-            total = admindivs.count()
-            for admindiv in admindivs:
-                # print ' ', admindiv.id, admindiv.code, admindiv.name
-
-                current += 1
-                if admindiv.geom is None:
-                    print '   ', ('{}-{} has null geometry'
-                                  .format(admindiv.code, admindiv.name))
-                    continue
-
-                reprojected = transform(
-                    project,
-                    to_shape(admindiv.geom))
-
-                output = Output()
-                output.hazardset = hazardset
-                output.administrativedivision = admindiv
-                output.hazardlevel = None
-
-                # TODO: calculate coverage ratio
-                output.coverage_ratio = 100
-
+            else:
                 for level in (u'HIG', u'MED', u'LOW'):
-                    layer = layers[level]
-                    src = readers[level]
+                    hazardlevel = HazardLevel.get(level)
+                    layer = DBSession.query(Layer) \
+                        .filter(Layer.hazardset_id == hazardset.id) \
+                        .filter(Layer.hazardlevel_id == hazardlevel.id) \
+                        .one()
+                    reader = rasterio.open(layer.path())
 
-                    if not reprojected.intersects(polygon):
-                        continue
+                    layers[level] = layer
+                    readers[level] = reader
 
-                    window = src.window(*reprojected.bounds)
-                    data = src.read(1, window=window, masked=True)
-                    if data.shape[0] * data.shape[1] == 0:
-                        continue
+            outputs = create_outputs(hazardset, layers, readers)
+            if outputs:
+                DBSession.add_all(outputs)
 
-                    threshold = get_threshold(hazardtype.mnemonic,
-                                              layer.local,
-                                              layer.hazardlevel.mnemonic,
-                                              layer.hazardunit)
-                    if threshold is None:
-                        print ("WARNING: no threshold found for {} {} {} {}"
-                               .format(hazardtype.mnemonic,
-                                       'local' if layer.local else 'global',
-                                       layer.hazardlevel.mnemonic,
-                                       layer.hazardunit))
-                        transaction.rollback()
-                        return False
-                    positive_data = (data > threshold).astype(rasterio.uint8)
-
-                    division = features.rasterize(
-                        ((g, 1) for g in [reprojected]),
-                        out_shape=data.shape,
-                        transform=src.window_transform(window),
-                        all_touched=True)
-
-                    masked = numpy.ma.masked_array(positive_data,
-                                                   mask=~division.astype(bool))
-
-                    if str(numpy.max(masked)) == str(numpy.ma.masked):
-                        break
-                    else:
-                        if output.hazardlevel is None:
-                            output.hazardlevel = level_VLO
-
-                    if numpy.max(masked) > 0:
-                        output.hazardlevel = layer.hazardlevel
-                        break
-
-                if output.hazardlevel is not None:
-                    # print '    hazardlevel :', output.hazardlevel.mnemonic
-                    DBSession.add(output)
-                    outputs += 1
-
-                percent = int(100.0 * current / total)
-                if percent % 10 == 0 and percent != last_percent:
-                    print '  ... processed {}%'.format(percent)
-                    last_percent = percent
-                    pass
+        finally:
+            logger.info("  Closing raster files")
+            for key, reader in readers.iteritems():
+                if reader and not reader.closed:
+                    reader.close()
 
     hazardset.processed = True
-
     DBSession.flush()
-    transaction.commit()
 
-    print ('Successfully processed {} divisions, {} outputs generated in {}'
-           .format(total, outputs, datetime.datetime.now() - chrono))
+    logger.info('  Successfully processed {}, {} outputs generated in {}'
+                .format(hazardset.id,
+                        len(outputs),
+                        datetime.datetime.now() - chrono))
+
+    return True
 
 
-def polygonFromBounds(bounds):
-    return Polygon([
-        (bounds[0], bounds[1]),
-        (bounds[0], bounds[3]),
-        (bounds[2], bounds[3]),
-        (bounds[2], bounds[1]),
-        (bounds[0], bounds[1])])
+def create_outputs(hazardset, layers, readers):
+    type_settings = settings['hazard_types'][hazardset.hazardtype.mnemonic]
+    adminlevel_REG = AdminLevelType.get(u'REG')
+
+    bbox = None
+    for reader in readers.itervalues():
+        polygon = polygon_from_boundingbox(reader.bounds)
+        if bbox is None:
+            bbox = polygon
+        else:
+            bbox = bbox.intersection(polygon)
+
+    admindivs = DBSession.query(AdministrativeDivision) \
+        .filter(AdministrativeDivision.leveltype_id == adminlevel_REG.id)
+
+    if hazardset.local:
+        # TODO : this could be optimized (double reprojection)
+        # Better to had a geom_4326 column
+        admindivs = admindivs \
+            .filter(
+                func.ST_Transform(AdministrativeDivision.geom, 4326)
+                .intersects(
+                    func.ST_GeomFromText(bbox.wkt, 4326))) \
+            .filter(func.ST_Intersects(
+                func.ST_Transform(AdministrativeDivision.geom, 4326),
+                func.ST_GeomFromText(bbox.wkt, 4326)))
+
+    current = 0
+    last_percent = 0
+    outputs = []
+    total = admindivs.count()
+    logger.info('  Iterating over {} administrative divisions'.format(total))
+    for admindiv in admindivs:
+        # print ' ', admindiv.id, admindiv.code, admindiv.name
+
+        current += 1
+        if admindiv.geom is None:
+            logger.warning('    {}-{} has null geometry'
+                           .format(admindiv.code, admindiv.name))
+            continue
+
+        reprojected = transform(
+            project,
+            to_shape(admindiv.geom))
+
+        if not reprojected.intersects(bbox):
+            continue
+
+        # Try block to include admindiv.code in exception message
+        try:
+            if type_settings['preprocessed']:
+                hazardlevel = preprocessed_hazardlevel(hazardset,
+                                                       layers[0], readers[0],
+                                                       reprojected)
+            else:
+                hazardlevel = notpreprocessed_hazardlevel(hazardset,
+                                                          layers, readers,
+                                                          reprojected)
+
+        except Exception as e:
+            e.message = ("{}-{} raise an exception :\n{}"
+                         .format(admindiv.code, admindiv.name, e.message))
+            raise
+
+        # Create output record
+        if hazardlevel is not None:
+            # print '    hazardlevel :', output.hazardlevel.mnemonic
+            output = Output()
+            output.hazardset = hazardset
+            output.administrativedivision = admindiv
+            output.hazardlevel = hazardlevel
+            # TODO: calculate coverage ratio
+            output.coverage_ratio = 100
+            outputs.append(output)
+
+        percent = int(100.0 * current / total)
+        if percent % 10 == 0 and percent != last_percent:
+            logger.info('  ... processed {}%'.format(percent))
+            last_percent = percent
+
+    return outputs
+
+
+def shape_size_exceeds(reader, bounds):
+    '''Check the size of the matrix to read from reader
+    Some multipolygons crosses the dateline.
+    This can result in a memory error with large raster files.
+    We bypass this iterate through polygons.
+    See admindiv.code = 28773 for example.
+    '''
+    window = reader.window(*bounds)
+    shape = window_shape(window)
+    if shape[0] * shape[1] * 4 > 100000000:
+        logger.debug("    iterate through multipolygon parts")
+        return True
+    return False
+
+
+def preprocessed_hazardlevel(hazardset, layer, reader, geometry):
+    type_settings = settings['hazard_types'][hazardset.hazardtype.mnemonic]
+
+    hazardlevel = None
+
+    if shape_size_exceeds(reader, geometry.bounds):
+        polygons = geometry.geoms
+    else:
+        polygons = geometry
+
+    for polygon in polygons:
+        window = reader.window(*polygon.bounds)
+        data = reader.read(1, window=window, masked=True)
+        if data.shape[0] * data.shape[1] == 0:
+            continue
+
+        division = features.rasterize(
+            ((g, 1) for g in [polygon]),
+            out_shape=data.shape,
+            transform=reader.window_transform(window),
+            all_touched=True)
+
+        masked = numpy.ma.masked_array(data,
+                                       mask=~division.astype(bool))
+
+        if str(numpy.max(masked)) == str(numpy.ma.masked):
+            continue
+
+        for level in (u'HIG', u'MED', u'LOW', u'VLO'):
+            level_obj = HazardLevel.get(unicode(level))
+            if level_obj <= hazardlevel:
+                break
+
+            if level in type_settings['values']:
+                values = type_settings['values'][level]
+                for value in values:
+                    if value in masked:
+                        hazardlevel = level_obj
+                        break
+
+    return hazardlevel
+
+
+def notpreprocessed_hazardlevel(hazardset, layers, readers, geometry):
+    type_settings = settings['hazard_types'][hazardset.hazardtype.mnemonic]
+    level_VLO = HazardLevel.get(u'VLO')
+
+    hazardlevel = None
+
+    for level in (u'HIG', u'MED', u'LOW'):
+        layer = layers[level]
+        reader = readers[level]
+
+        threshold = get_threshold(hazardset.hazardtype.mnemonic,
+                                  layer.local,
+                                  layer.hazardlevel.mnemonic,
+                                  layer.hazardunit)
+        if threshold is None:
+            raise ProcessException(
+                'No threshold found for {} {} {} {}'
+                .format(hazardset.hazardtype.mnemonic,
+                        'local' if layer.local else 'global',
+                        layer.hazardlevel.mnemonic,
+                        layer.hazardunit))
+
+        if shape_size_exceeds(reader, geometry.bounds):
+            polygons = geometry.geoms
+        else:
+            polygons = geometry
+
+        for polygon in polygons:
+
+            window = reader.window(*polygon.bounds)
+            data = reader.read(1, window=window, masked=True)
+
+            if data.shape[0] * data.shape[1] == 0:
+                continue
+
+            if ('inverted_comparison' in type_settings and
+                    type_settings['inverted_comparison']):
+                positive_data = (data < threshold).astype(rasterio.uint8)
+            else:
+                positive_data = (data > threshold).astype(rasterio.uint8)
+
+            division = features.rasterize(
+                ((g, 1) for g in [polygon]),
+                out_shape=data.shape,
+                transform=reader.window_transform(window),
+                all_touched=True)
+
+            masked = numpy.ma.masked_array(positive_data,
+                                           mask=~division.astype(bool))
+
+            if str(numpy.max(masked)) == str(numpy.ma.masked):
+                continue
+
+            if hazardlevel is None:
+                hazardlevel = level_VLO
+
+            if numpy.max(masked) > 0:
+                hazardlevel = layer.hazardlevel
+                break
+
+        if hazardlevel == layer.hazardlevel:
+            break
+
+    return hazardlevel
+
+
+def polygon_from_boundingbox(boundingbox):
+    return box(boundingbox[0],
+               boundingbox[1],
+               boundingbox[2],
+               boundingbox[3])
 
 
 def get_threshold(hazardtype, local, level, unit):
     mysettings = settings['hazard_types'][hazardtype]['thresholds']
-    if type(mysettings) in (int, float):
-        return float(mysettings)
-    if 'local' in mysettings.keys():
-        mysettings = mysettings['local'] if local else mysettings['global']
-    if 'HIG' in mysettings.keys():
-        mysettings = mysettings[level]
-    if unit in mysettings.keys():
-        mysettings = mysettings[unit]
-        return float(mysettings)
+    while type(mysettings) is dict:
+        if 'local' in mysettings.keys():
+            mysettings = mysettings['local'] if local else mysettings['global']
+        elif 'HIG' in mysettings.keys():
+            mysettings = mysettings[level]
+        elif unit in mysettings.keys():
+            mysettings = mysettings[unit]
+    return float(mysettings)

--- a/thinkhazard_processing/processing.py
+++ b/thinkhazard_processing/processing.py
@@ -103,7 +103,8 @@ def process_hazardset(hazardset_id, force=False):
             # Open rasters
             layers = {}
             readers = {}
-            if type_settings['preprocessed']:
+            if 'values' in type_settings.keys():
+                # preprocessed layer
                 layer = DBSession.query(Layer) \
                     .filter(Layer.hazardset_id == hazardset.id) \
                     .one()
@@ -194,7 +195,8 @@ def create_outputs(hazardset, layers, readers):
 
         # Try block to include admindiv.code in exception message
         try:
-            if type_settings['preprocessed']:
+            if 'values' in type_settings.keys():
+                # preprocessed layer
                 hazardlevel = preprocessed_hazardlevel(hazardset,
                                                        layers[0], readers[0],
                                                        reprojected)

--- a/thinkhazard_processing/scripts/process.py
+++ b/thinkhazard_processing/scripts/process.py
@@ -15,6 +15,10 @@ def main(argv=sys.argv):
         '--force', dest='force',
         action='store_const', const=True, default=False,
         help='Force execution even if hazardset has already been processed')
+    parser.add_argument(
+        '--dry-run', dest='dry_run',
+        action='store_const', const=True, default=False,
+        help='Perform a trial run that do not commit changes')
     args = parser.parse_args(argv[1:])
 
     engine = engine_from_config(settings, 'sqlalchemy.')
@@ -22,4 +26,5 @@ def main(argv=sys.argv):
 
     process(
         hazardset_id=args.hazardset_id,
-        force=args.force)
+        force=args.force,
+        dry_run=args.dry_run)

--- a/thinkhazard_processing/scripts/process.py
+++ b/thinkhazard_processing/scripts/process.py
@@ -10,7 +10,7 @@ def main(argv=sys.argv):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--hazardset_id',  dest='hazardset_id', action='store',
-        help='The hazard set identifier')
+        help='The hazardset identifier')
     parser.add_argument(
         '--force', dest='force',
         action='store_const', const=True, default=False,
@@ -18,7 +18,7 @@ def main(argv=sys.argv):
     parser.add_argument(
         '--dry-run', dest='dry_run',
         action='store_const', const=True, default=False,
-        help='Perform a trial run that do not commit changes')
+        help='Perform a trial run that does not commit changes')
     args = parser.parse_args(argv[1:])
 
     engine = engine_from_config(settings, 'sqlalchemy.')

--- a/thinkhazard_processing/tests/test_process.py
+++ b/thinkhazard_processing/tests/test_process.py
@@ -1,5 +1,6 @@
 import unittest
 import transaction
+import logging
 from datetime import datetime
 from shapely.geometry import (
     MultiPolygon,
@@ -25,6 +26,9 @@ from ..models import (
     )
 from ..processing import process
 from common import new_geonode_id
+
+
+logging.getLogger(process.__module__).setLevel(logging.WARN)
 
 
 def populate():

--- a/thinkhazard_processing/tests/test_process.py
+++ b/thinkhazard_processing/tests/test_process.py
@@ -163,12 +163,12 @@ def populate_processing():
     hazardset.metadata_lastupdated_date = datetime.now()
     DBSession.add(hazardset)
 
-    return_periods = hazardtype_settings['global']['return_periods']
-    unit = hazardtype_settings['thresholds'].keys()[0]
+    return_periods = hazardtype_settings['return_periods']
+    unit = 'test'
 
     for level in (u'HIG', u'MED', u'LOW'):
         hazardlevel = HazardLevel.get(level)
-        return_period = return_periods[level]
+        return_period = return_periods[level][0]
 
         layer = Layer()
         layer.title = "{}-{}".format(id, return_period)


### PR DESCRIPTION
- Change decision tree by pure SQL one, less memory and time consuming.
- Process preprocessed hazardsets.
- Complete readme with detailed informations on settings.

Depends on https://github.com/GFDRR/thinkhazard_common/pull/10

Note that we don't force anymore the ZopeTransaction keep_session to True. We use only the hazardset id in main loop so we don't keep any object from the session after transaction commit or abort call.

Upgrade database with : 

```
ALTER TABLE processing.layer
    DROP CONSTRAINT layer_pkey,
    DROP CONSTRAINT layer_geonode_id_key;

ALTER TABLE processing.layer
    ADD CONSTRAINT layer_pkey PRIMARY KEY (geonode_id);

ALTER TABLE processing.layer
    ALTER COLUMN hazardlevel_id DROP NOT NULL,
    ALTER COLUMN return_period DROP NOT NULL,
    ALTER COLUMN hazardunit DROP NOT NULL;
ALTER TABLE processing.layer
    ADD CONSTRAINT layer_hazardlevel_id_key UNIQUE(hazardset_id, hazardlevel_id);
```
