### PR TITLE
Optimize processing memory usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ rasterio==0.30.0
 pyproj==1.9.4
 shapely==1.5.13
 httplib2==0.9.2
-git+https://github.com/GFDRR/thinkhazard_common.git@0fbb976f8a5e30e902f1fab1b694d495c3d1209f#egg=thinkhazard_common
+git+https://github.com/GFDRR/thinkhazard_common.git@cfa27cf11257eeb66e2505ab64cd46590b677fdc#egg=thinkhazard_common
 -e .


### PR DESCRIPTION
- Iterate over admindiv primary key identifier, retrieve and expunge records one by one in loop.
- Remove admindiv geometry simplification.

This modifications increase the processing time by approximatively 25% to save 700Mo of memory on global hazardsets.
